### PR TITLE
Wrap stdouts in a isTTY check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ scss-lint-report.xml
 # folders
 node_modules
 dist
+.idea

--- a/bin/svgson.js
+++ b/bin/svgson.js
@@ -8,7 +8,7 @@ const path    = require('path');
 const Promise = require('promise');
 const chalk   = require('chalk');
 const svgson  = require('../lib/svgson');
-const version = require('../package.json').version
+const version = require('../package.json').version;
 const list = (val) => val.split(',');
 
 program
@@ -120,9 +120,11 @@ const processFile = (file) => {
   const fileName = path.basename(file, fileExt);
   return new Promise((resolve,reject) => {
     return fs.readFile(filePath, 'utf8').then(data => {
-      process.stdout.cursorTo(0);
-      process.stdout.clearLine();
-      process.stdout.write(file);
+      if (require('tty').isatty(1)) {
+        process.stdout.cursorTo(0);
+        process.stdout.clearLine();
+        process.stdout.write(file);
+      }
       svgson(data, applyExtras(fileName), resolve);
     });
   });
@@ -133,8 +135,10 @@ const toJSON = (obj, pretty) => {
 };
 
 const printFile = (obj) => {
-  process.stdout.clearLine();
-  process.stdout.cursorTo(0);
+  if (require('tty').isatty(1)) {
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+  }
   console.log(`--- ${chalk.yellow('Transforming into')}${program.pretty ? chalk.gray(' Prettyfied') : ''} ${chalk.yellow('JSON notation')}`)
   return toJSON(obj, program.pretty);
 };

--- a/bin/svgson.js
+++ b/bin/svgson.js
@@ -10,6 +10,7 @@ const chalk   = require('chalk');
 const svgson  = require('../lib/svgson');
 const version = require('../package.json').version;
 const list = (val) => val.split(',');
+const tty = require('tty');
 
 program
   .version(version)
@@ -120,7 +121,7 @@ const processFile = (file) => {
   const fileName = path.basename(file, fileExt);
   return new Promise((resolve,reject) => {
     return fs.readFile(filePath, 'utf8').then(data => {
-      if (require('tty').isatty(1)) {
+      if (tty.isatty(1)) {
         process.stdout.cursorTo(0);
         process.stdout.clearLine();
         process.stdout.write(file);
@@ -135,7 +136,7 @@ const toJSON = (obj, pretty) => {
 };
 
 const printFile = (obj) => {
-  if (require('tty').isatty(1)) {
+  if (tty.isatty(1)) {
     process.stdout.clearLine();
     process.stdout.cursorTo(0);
   }


### PR DESCRIPTION
Wraps `process.stdout` functions in a TTY check to stop it breaking in non TTY environments (Webstorm / Travis CI bug).

Fixes #3 