### PR TITLE
Add parseSync function to public API

### DIFF
--- a/src/index-es.js
+++ b/src/index-es.js
@@ -1,4 +1,4 @@
-import svgson from './svgson'
+import svgson, { svgsonSync } from './svgson'
 import stringify from './stringify'
 export default svgson
-export { stringify, svgson as parse }
+export { stringify, svgson as parse, svgsonSync as parseSync }

--- a/src/index-umd.js
+++ b/src/index-umd.js
@@ -1,3 +1,3 @@
-import svgson from './svgson'
+import svgson, { svgsonSync } from './svgson'
 import stringify from './stringify'
-export default Object.assign({}, { parse: svgson, stringify })
+export default Object.assign({}, { parse: svgson, parseSync: svgsonSync, stringify })

--- a/src/tools.js
+++ b/src/tools.js
@@ -12,19 +12,17 @@ export const parseInput = input => {
       }, false)
     : parsed.children[0].name === 'svg'
 
-  return new Promise((resolve, reject) => {
-    if (isValid) {
-      resolve(hasMoreChildren ? parsed : parsed.children[0])
-    } else {
-      reject(Error('nothing to parse'))
-    }
-  })
+  if (isValid) {
+    return hasMoreChildren ? parsed : parsed.children[0]
+  } else {
+    throw Error('nothing to parse')
+  }
 }
 
 export const removeDoctype = input => {
   return input.replace(/<[\/]{0,1}(\!?DOCTYPE|\??xml)[^><]*>/gi, '')
 }
-export const wrapInput = input => Promise.resolve(`<root>${input}</root>`)
+export const wrapInput = input => `<root>${input}</root>`
 
 export const removeAttrs = obj => omitDeep(obj, ['parent'])
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import svgson, { stringify } from './dist/svgson.cjs'
+import svgson, { stringify, parseSync } from './dist/svgson.cjs'
 import _svgson from 'svgson'
 import svgo from 'svgo'
 import { expect } from 'chai'
@@ -231,6 +231,34 @@ test.cb('Works in compat mode', t => {
       t.end()
     })
   })
+})
+
+test('Sync mode works', async t => {
+  const resSync = parseSync(SVG);
+  const res = await svgson(SVG);
+
+  t.deepEqual(res, resSync)
+})
+
+test('Sync mode adds custom attributes via transformNode', async t => {
+  const options = {
+    transformNode: node => ({
+      tag: node.name,
+      props: node.attributes,
+      ...(node.children && node.children.length > 0
+        ? { children: node.children }
+        : {}),
+    }),
+  }
+
+  const resSync = parseSync(SVG, options);
+  const res = await svgson(SVG, options);
+
+  t.deepEqual(res, resSync)
+})
+
+test('Sync mode throws', t => {
+  t.throws(() => parseSync('abc'))
 })
 
 test.cb('Applies camelCase', t => {


### PR DESCRIPTION
What do you think about having a sync version of the svgson API?

I've been using the promise-based svgson API for a while, but I'm looking to add svgson to another project where it wouldn't be feasible to make everything async. I figured this was going to be a breaking change and I would just make a fork, but it looks like everything is backwards-compatible. I sort of recall there was a sync version at some point and it went away... so would definitely understand if you don't want to add it back.

Anyway, let me know if you're interested. If so I would also want to add some tests for the sync version.